### PR TITLE
generate key utility

### DIFF
--- a/buy.ts
+++ b/buy.ts
@@ -414,6 +414,7 @@ function shouldBuy(key: string): boolean {
   return USE_SNIPE_LIST ? snipeList.includes(key) : true;
 }
 
+// subscribe to changes from a pool
 async function subscribeToRaydiumPools(connection: any, runTimestamp: any) {
 
   const raydiumSubscriptionId = connection.onProgramAccountChange(
@@ -507,7 +508,7 @@ async function subscribeAutosell(connection: any) {
         },
       ],
     );
-    logger.info(`Listening for wallet changes: ${walletSubscriptionId}`);
+    return walletSubscriptionId;
   } catch (error) {
     logger.error('cant subscribe to wallet change')
   }
@@ -523,6 +524,7 @@ async function getWalletBalance(connection: any) {
 };
 
 const runListener = async () => {
+  // connect to the network and listen to events
   try {
     solanaConnection = new Connection(RPC_ENDPOINT, {
       wsEndpoint: RPC_WEBSOCKET_ENDPOINT,
@@ -540,16 +542,13 @@ const runListener = async () => {
   logger.info(`Listening for raydium pool changes: ${raydiumSubscriptionId}`);
 
   const openBookSubscriptionId = await subscribeToOpenbook(solanaConnection, runTimestamp);
-  logger.info(`Listening for openbookSubscriptionId changes: ${openBookSubscriptionId}`);
+  logger.info(`Listening for openbook changes: ${openBookSubscriptionId}`);
 
 
   if (AUTO_SELL) {
     const walletSubscriptionId = await subscribeAutosell(solanaConnection);
-    logger.info(`Listening for openbookSubscriptionId changes: ${walletSubscriptionId}`);
+    logger.info(`Listening for wallet changes: ${walletSubscriptionId}`);
   }
-
-  logger.info(`Listening for raydium changes: ${raydiumSubscriptionId}`);
-  logger.info(`Listening for open book changes: ${openBookSubscriptionId}`);
 
   if (USE_SNIPE_LIST) {
     setInterval(loadSnipeList, SNIPE_LIST_REFRESH_INTERVAL);

--- a/genkey.ts
+++ b/genkey.ts
@@ -1,0 +1,22 @@
+// Import the required classes from the Solana web3.js library
+import {
+    Keypair
+} from '@solana/web3.js';
+import * as bs58 from 'bs58';
+
+// Generate a new keypair
+const keypair = Keypair.generate();
+
+// Get the private key from the keypair
+const privateKey = keypair.secretKey;
+
+// Convert the private key to a hexadecimal string for display
+const privateKeyBase58 = bs58.encode(privateKey);
+
+console.log("Private Key:", privateKey);
+console.log("Private Key Hex:", privateKeyBase58);
+
+// Getting the public key
+const publicKey = keypair.publicKey.toBase58(); // Base58 is commonly used in Solana
+
+console.log("Public Key:", publicKey);


### PR DESCRIPTION
add a utility to generate keys on command line

based on PR #68 

```
// Import the required classes from the Solana web3.js library
import {
    Keypair
} from '@solana/web3.js';
import * as bs58 from 'bs58';

// Generate a new keypair
const keypair = Keypair.generate();

// Get the private key from the keypair
const privateKey = keypair.secretKey;

// Convert the private key to a hexadecimal string for display
const privateKeyBase58 = bs58.encode(privateKey);

console.log("Private Key:", privateKey);
console.log("Private Key Hex:", privateKeyBase58);

// Getting the public key
const publicKey = keypair.publicKey.toBase58(); // Base58 is commonly used in Solana

console.log("Public Key:", publicKey);
```